### PR TITLE
Fix /live/ urls not having full url in json output

### DIFF
--- a/youtube-community-tab/src/youtube_community_tab/helpers/clean_items.py
+++ b/youtube-community-tab/src/youtube_community_tab/helpers/clean_items.py
@@ -12,9 +12,10 @@ def clean_content_text(content):
                 url = item["navigationEndpoint"]["urlEndpoint"]["url"]
                 # replace redirects with direct links
                 if url.startswith("https://www.youtube.com/redirect"):
-                    parsed_url = urlparse(item["navigationEndpoint"]["urlEndpoint"]["url"])
+                    parsed_url = urlparse(url)
                     redirect_url = parse_qs(parsed_url.query)["q"][0]
-                    item["urlEndpoint"] = {"url": unquote(redirect_url)}
+                    url = unquote(redirect_url)
+                item["urlEndpoint"] = {"url": url}
                 item.pop("navigationEndpoint")
             # hashtags
             elif "browseEndpoint" in item["navigationEndpoint"]:


### PR DESCRIPTION
Function helpers.clean_items.clean_content_text always pops ["navigationEndpoint"]["urlEndpoint"] from text item if it exists, but  only adds it back if url is redirect outside of Youtube or hashtag. There is at least one entry type that has "urlEndpoint" field but is not redirect: livestream url "https://youtube.com/live/video_id", which ends up missing full url in output file.