### PR TITLE
Fix ytct.py not working without cookies file

### DIFF
--- a/ytct.py
+++ b/ytct.py
@@ -38,15 +38,31 @@ def get_arguments():
     parser.add_argument("links", metavar="CHANNEL", nargs="*", help="youtube channel or community post link/id")
     return parser.parse_args()
 
+def use_default_cookies():
+    requests_cache.cookies.set(
+        'SOCS',
+        'CAESNQgDEitib3FfaWRlbnRpdHlmcm9udGVuZHVpc2VydmVyXzIwMjIwNzA1LjE2X3AwGgJwdCACGgYIgOedlgY',
+        domain='.youtube.com',
+        path='/'
+    )
+    requests_cache.cookies.set(
+        'CONSENT',
+        'PENDING+917',
+        domain='.youtube.com',
+        path='/'
+    )
+
 def use_cookies(cookie_jar_path):
     cookie_jar = cookiejar.MozillaCookieJar(cookie_jar_path)
     try:
         cookie_jar.load()
         print_log("ytct", f"loaded cookies from {cookie_jar_path}")
     except FileNotFoundError:
+        use_default_cookies()
         print_log("ytct", f"could not find cookies file {cookie_jar_path}, continuing without cookies...")
         return
     except (cookiejar.LoadError, OSError) as e:
+        use_default_cookies()
         print_log("ytct", f"{e}")
         print_log("ytct", f"failed to load cookies from {cookie_jar_path}, continuing without cookies")
         return
@@ -249,6 +265,8 @@ if __name__ == "__main__":
     # set cookies for retrieving posts that need auth
     if args.cookies:
         use_cookies(args.cookies)
+    else:
+        use_default_cookies()
     usable_archive = None
     if args.post_archive:
         try:

--- a/ytct.py
+++ b/ytct.py
@@ -43,7 +43,11 @@ def use_cookies(cookie_jar_path):
     try:
         cookie_jar.load()
         print_log("ytct", f"loaded cookies from {cookie_jar_path}")
-    except:
+    except FileNotFoundError:
+        print_log("ytct", f"could not find cookies file {cookie_jar_path}, continuing without cookies...")
+        return
+    except (cookiejar.LoadError, OSError) as e:
+        print_log("ytct", f"{e}")
         print_log("ytct", f"failed to load cookies from {cookie_jar_path}, continuing without cookies")
         return
     requests_cache.cookies = cookie_jar
@@ -244,10 +248,7 @@ if __name__ == "__main__":
     args = get_arguments()
     # set cookies for retrieving posts that need auth
     if args.cookies:
-        if os.path.isfile(args.cookies):
-            use_cookies(args.cookies)
-        else:
-            print_log("ytct", f"could not find cookies file \'{args.cookies}\', continuing without cookies...")
+        use_cookies(args.cookies)
     usable_archive = None
     if args.post_archive:
         try:


### PR DESCRIPTION
When running script without --cookies argument passed, I get 
```
    data = json.loads(m[0])
                      ~^^^
IndexError: list index out of range
```
happening [here](https://github.com/HoloArchivists/youtube-community-tab/blob/87f6219770e112b22a0c7c64ab6dc0fc35d3893f/youtube-community-tab/src/youtube_community_tab/post.py#L71) when downloading a single post and [here](https://github.com/HoloArchivists/youtube-community-tab/blob/87f6219770e112b22a0c7c64ab6dc0fc35d3893f/youtube-community-tab/src/youtube_community_tab/community_tab.py#L60) for entire channel.

Upstream repository has closed issue bot-jonas/youtube-community-tab#3, from which it seems that error might be caused by absence of "cookies allowed" cookie, and indeed, when I dumped raw response in file it was prompt to accept Youtube cookies.

This PR adds cookies from [this](https://github.com/bot-jonas/youtube-community-tab/issues/3#issuecomment-1179363154) reply as default to use when no --cookies passed or error parsing them happened.