### PR TITLE
Add reposts support

### DIFF
--- a/youtube-community-tab/src/youtube_community_tab/community_tab.py
+++ b/youtube-community-tab/src/youtube_community_tab/community_tab.py
@@ -119,16 +119,19 @@ class CommunityTab(object):
                     post_data["channelId"] = self.channel_id
                     self.posts.append(Post.from_data(post_data))
                 elif post_kind == "sharedPostRenderer":
-                    # TODO: parse data from item[kind]["post"]["sharedPostRenderer"]["originalPost"]["backstagePostRenderer"]
                     post_data = item[kind]["post"]["sharedPostRenderer"]
                     post_data["channelId"] = self.channel_id
-                    post_data["authorText"] = post_data["displayName"]
-                    post_data["authorEndpoint"] = post_data["endpoint"]
-                    post_data.pop("displayName")
-                    post_data.pop("endpoint")
+                    post_data["authorText"] = post_data.pop("displayName")
+                    post_data["authorEndpoint"] = post_data.pop("endpoint")
+                    post_data["contentText"] = post_data.pop("content")
+
+                    original_post_data = post_data.pop("originalPost")["backstagePostRenderer"]
+                    original_post_data["channelId"] = original_post_data["authorEndpoint"]["browseEndpoint"]["browseId"]
+                    post_data["originalPost"] = Post.from_data(original_post_data)
+
                     self.posts.append(Post.from_data(post_data))
                 else:
-                    raise Exception(f"[post_kind={post_kind} is not implemented yet!]")
+                    raise NotImplementedError(f"[post_kind={post_kind} is not implemented yet!]")
             elif kind == "continuationItemRenderer":
                 self.posts_continuation_token = item[kind]["continuationEndpoint"]["continuationCommand"]["token"]
                 there_is_no_continuation_token = False

--- a/youtube-community-tab/src/youtube_community_tab/community_tab.py
+++ b/youtube-community-tab/src/youtube_community_tab/community_tab.py
@@ -113,25 +113,8 @@ class CommunityTab(object):
             kind = list(item.keys())[0]
 
             if kind == "backstagePostThreadRenderer":
-                post_kind = list(item[kind]["post"].keys())[0]
-                if post_kind == "backstagePostRenderer":
-                    post_data = item[kind]["post"]["backstagePostRenderer"]
-                    post_data["channelId"] = self.channel_id
-                    self.posts.append(Post.from_data(post_data))
-                elif post_kind == "sharedPostRenderer":
-                    post_data = item[kind]["post"]["sharedPostRenderer"]
-                    post_data["channelId"] = self.channel_id
-                    post_data["authorText"] = post_data.pop("displayName")
-                    post_data["authorEndpoint"] = post_data.pop("endpoint")
-                    post_data["contentText"] = post_data.pop("content")
-
-                    original_post_data = post_data.pop("originalPost")["backstagePostRenderer"]
-                    original_post_data["channelId"] = original_post_data["authorEndpoint"]["browseEndpoint"]["browseId"]
-                    post_data["originalPost"] = Post.from_data(original_post_data)
-
-                    self.posts.append(Post.from_data(post_data))
-                else:
-                    raise NotImplementedError(f"[post_kind={post_kind} is not implemented yet!]")
+                post_data = item["backstagePostThreadRenderer"]["post"]
+                self.posts.append(Post.from_data(post_data))
             elif kind == "continuationItemRenderer":
                 self.posts_continuation_token = item[kind]["continuationEndpoint"]["continuationCommand"]["token"]
                 there_is_no_continuation_token = False


### PR DESCRIPTION
youtube-community-tab already has some code for parsing it, but it doesn't add original or reposted text in json output.
This branch fixes parsing, adds original post content to `Post.original_post` property and adapts ytct to add timestamp info and download images for it.